### PR TITLE
Fix preloadPageCount on ViewPort

### DIFF
--- a/lib/preload_page_view.dart
+++ b/lib/preload_page_view.dart
@@ -3,7 +3,6 @@ library preload_page_view;
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -608,17 +607,9 @@ class _PreloadPageViewState extends State<PreloadPageView> {
         viewportBuilder: (BuildContext context, ViewportOffset position) {
           return Viewport(
             clipBehavior: widget.clipBehavior,
-            cacheExtent: _preloadPagesCount < 1
-                ? 0
-                : (_preloadPagesCount == 1
-                    ? 1
-                    : widget.scrollDirection == Axis.horizontal
-                        ? MediaQuery.of(context).size.width *
-                                _preloadPagesCount -
-                            1
-                        : MediaQuery.of(context).size.height *
-                                _preloadPagesCount -
-                            1),
+            cacheExtent:
+                _preloadPagesCount < 1 ? 0 : _preloadPagesCount.toDouble(),
+            cacheExtentStyle: CacheExtentStyle.viewport,
             axisDirection: axisDirection,
             offset: position,
             slivers: <Widget>[


### PR DESCRIPTION
The PR contains fix for the `preloadPageCount` param, because if it is more than `1` it works incorrectly (loads too much pages).

Not it loads the current page + preloadPageCount for both scroll directions properly.